### PR TITLE
Fallback to ::Logger if Rails::Logger not loaded

### DIFF
--- a/lib/rails-callback_log.rb
+++ b/lib/rails-callback_log.rb
@@ -10,7 +10,7 @@ module RailsCallbackLog
 
   class << self
     def logger
-      @_logger ||= ::Rails.logger || Logger.new(STDOUT)
+      @_logger ||= ::Rails.logger || ::Logger.new(STDOUT)
     end
 
     def matches_filter?(str)

--- a/lib/rails-callback_log.rb
+++ b/lib/rails-callback_log.rb
@@ -10,7 +10,7 @@ module RailsCallbackLog
 
   class << self
     def logger
-      @_logger ||= ::Rails.logger || ::Logger.new(STDOUT)
+      ::Rails.logger || ::Logger.new(STDOUT)
     end
 
     def matches_filter?(str)

--- a/lib/rails-callback_log.rb
+++ b/lib/rails-callback_log.rb
@@ -9,6 +9,10 @@ module RailsCallbackLog
   FILTER = ENV["RAILS_CALLBACK_LOG_FILTER"].present?.freeze
 
   class << self
+    def logger
+      @_logger ||= ::Rails.logger || Logger.new(STDOUT)
+    end
+
     def matches_filter?(str)
       source_location_filters.any? { |f| str.start_with?(f) }
     end
@@ -28,7 +32,7 @@ module RailsCallbackLog
       lambda { |*args, &block|
         if !::RailsCallbackLog::FILTER ||
           caller.any? { |line| ::RailsCallbackLog.matches_filter?(line) }
-          ::Rails.logger.debug(format("Callback: %s", @method_name))
+          ::RailsCallbackLog.logger.debug(format("Callback: %s", @method_name))
         end
         original_lambda.call(*args, &block)
       }
@@ -43,7 +47,7 @@ module RailsCallbackLog
       lambda { |*args, &block|
         if !::RailsCallbackLog::FILTER ||
           caller.any? { |line| ::RailsCallbackLog.matches_filter?(line) }
-          ::Rails.logger.debug(format("Callback: %s", filter))
+          ::RailsCallbackLog.logger.debug(format("Callback: %s", filter))
         end
         original_lambda.call(*args, &block)
       }

--- a/spec/rails-callback_log_spec.rb
+++ b/spec/rails-callback_log_spec.rb
@@ -16,7 +16,7 @@ module ActiveSupport
             # Mock the rails logger. We're going to expect it to receive a `debug` message.
             logger = double
             allow(logger).to receive(:debug)
-            allow(::Rails).to receive(:logger).and_return(logger)
+            allow(::RailsCallbackLog).to receive(:logger).and_return(logger)
             target = double
 
             # Symbol-based callbacks have a `target` and a `value`. The definition of

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,10 +7,6 @@ module Rails
   def self.gem_version
     ::ActiveSupport.gem_version
   end
-
-  def self.logger
-    ::ActiveSupport::Logger.new(STDOUT)
-  end
 end
 
 require "rails-callback_log"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,10 @@ module Rails
   def self.gem_version
     ::ActiveSupport.gem_version
   end
+
+  def self.logger
+    ::ActiveSupport::Logger.new(STDOUT)
+  end
 end
 
 require "rails-callback_log"


### PR DESCRIPTION
Some rake tasks do not load the `:environment` task, and so `::Rails::Logger` is `nil`. In those cases, we fallback to `::Logger.new(STDOUT)`

Fixes #2