### PR TITLE
Fix Rails 5.1 and up output to match pre 5.1 output

### DIFF
--- a/spec/output_spec.rb
+++ b/spec/output_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+class CallbackWrapper
+  def after(record)
+    Rails.logger.info("- in CallbackWrapper after method")
+  end
+end
+
+class CallbackTester
+  include ActiveSupport::Callbacks
+  define_callbacks :save
+
+  def save
+    run_callbacks :save do
+      Rails.logger.info("- save")
+    end
+  end
+
+  # Set a proc based callback
+  set_callback :save, :before do
+    Rails.logger.info("- in before save callback")
+  end
+
+  # Set an object based callback, will call `after` on CallbackWrapper
+  set_callback :save, :after, CallbackWrapper.new
+
+  # Set a symbol based method reference callback
+  set_callback :save, :around, :around_callback
+  def around_callback
+    Rails.logger.info("- in around callback before")
+    yield
+    Rails.logger.info("- in around callback after")
+  end
+end
+
+describe RailsCallbackLog do
+  # Filter the logs down to only the lines that start with Callback. Makes the
+  # test output easier to read.
+  subject(:filtered_log) do
+    output.string.split("\n").select { |line| line =~ /^Callback/ }.join("\n")
+  end
+
+  # Create a logger that logs to a StringIO that we can test against
+  let(:output) { StringIO.new }
+  let(:logger) do
+    logger = Logger.new(output)
+    logger.formatter = proc { |severity, datetime, progname, msg|
+      "#{msg}\n"
+    }
+    logger
+  end
+
+  before do
+    # Set the logger to our custom StringIO logger
+    Rails.logger = logger
+  end
+
+  describe ".log" do
+    it "logs all of the callbacks" do
+      CallbackTester.new.save
+
+      expect(filtered_log).to include "Callback: #<Proc:"
+      expect(filtered_log).to include "Callback: around_callback"
+      expect(filtered_log).to include "Callback: #<CallbackWrapper:"
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,10 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 # is loaded. We don't want to load all of rails just to run our tests, so we simply
 # define `::Rails.gem_version`.
 module Rails
+  class << self
+    attr_accessor :logger
+  end
+
   def self.gem_version
     ::ActiveSupport.gem_version
   end


### PR DESCRIPTION
After a bit more digging I decided that the `expand` method was the best place to hook into to add logging on 5.1 and up. When running the callbacks rails calls `expand` to get the object and method that need to be executed and then runs it. e.g.
```ruby
target, block, method, *arguments = expand(target, value, block)
target.send(method, *arguments, &block)
```
The basic flow is that for :before and :after callbacks the `CallbackChain` calls `make_lambda` that then calls `expand` and then executes the callback. For :around callbacks the `CallbackChain` directly calls `expand` and then executes the callback. For this reason I think `expand` is the easiest place to hook into.

I added a test that checks the output of the logging and ensures that it is the same across all versions. I tested this against 4.2, 5.0, 5.1, 5.2, and 6.0.beta1 and everything worked the same.