### PR TITLE
Logging toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ unset RAILS_CALLBACK_LOG_FILTER
 
 Filtering incurs a serious performance penalty, so it is off by default.
 
+## Logging only upon opt-in
+When working in a team and logging is needed only for select members, use this environment-based opt-in pattern:
+
+```rb
+# in Gemfile
+gem "rails-callback_log", group: [:development, :test], require: false
+
+# in some config/initializers/callback_log.rb
+require "rails-callback_log" if ENV["LOG_RAILS_CALLBACKS"] == "true"
+```
+
 ## See Also
 
 - http://stackoverflow.com/q/13089936/567762


### PR DESCRIPTION
Hello!

We're using this gem to track down slow and unnecessary callbacks in a large project. Unfortunately, most team members do not need to see the debug messages.
To avoid having to maintain separate branches with the gem enabled and disabled, I added a simple config layer that allows toggling the gem on and off with an environmental variable.

Hope you accept this PR.